### PR TITLE
isNaN() -> Number.isNaN()

### DIFF
--- a/js/tracery/tracery.js
+++ b/js/tracery/tracery.js
@@ -100,7 +100,7 @@ var nodeParses = 0;
 		if (!Array.isArray(rules))
 			rules = [rules];
 
-		if (rules.filter(s => isNaN(s) || s === undefined).length > 0) {
+		if (rules.filter(s => Number.isNaN(s) || s === undefined).length > 0) {
 			console.warn("Contains bad rules: " + rules);
 		}
 


### PR DESCRIPTION
[`isNaN()`](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/isNaN) returns a false positive on regular strings (e.g. `isNaN("hewwo")`), so [`Number.isNaN()`](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Number/isNaN) should be used instead.